### PR TITLE
Cmd userdel

### DIFF
--- a/moler/cmd/unix/userdel.py
+++ b/moler/cmd/unix/userdel.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Userdel command module.
+"""
+
+__author__ = 'Agnieszka Bylica'
+__copyright__ = 'Copyright (C) 2018, Nokia'
+__email__ = 'agnieszka.bylica@nokia.com'
+
+
+import re
+
+from moler.cmd.unix.genericunix import GenericUnixCommand
+from moler.exceptions import CommandFailure
+from moler.exceptions import ParsingDone
+
+
+class Userdel(GenericUnixCommand):
+    def __init__(self, connection, prompt=None, new_line_chars=None, options=None, user=None):
+        super(Userdel, self).__init__(connection=connection, prompt=prompt, new_line_chars=new_line_chars)
+
+        self.options = options
+        self.user = user
+
+        self.current_ret['RESULT'] = list()
+
+    def build_command_string(self):
+        cmd = "userdel"
+        return cmd
+
+    def on_new_line(self, line, is_full_line):
+        if is_full_line:
+            try:
+                self._parse_line(line)
+            except ParsingDone:
+                pass
+        return super(Userdel, self).on_new_line(line, is_full_line)

--- a/test/unix/test_cmd_userdel.py
+++ b/test/unix/test_cmd_userdel.py
@@ -15,5 +15,23 @@ from moler.cmd.unix.userdel import Userdel
 
 
 def test_userdel_returns_proper_command_string(buffer_connection):
-    useradd_cmd = Userdel(buffer_connection, user='xyz', prompt=None, new_line_chars=None)
-    assert "useradd xyz" == useradd_cmd.command_string
+    userdel_cmd = Userdel(connection=buffer_connection.moler_connection, user='xyz', prompt=None, new_line_chars=None)
+    assert "userdel xyz" == userdel_cmd.command_string
+
+
+def test_userdel_raises_command_error(buffer_connection):
+    command_output, expected_result = command_output_and_expected_result()
+    buffer_connection.remote_inject_response([command_output])
+    userdel_cmd = Userdel(connection=buffer_connection.moler_connection, user='xyz', prompt=None, new_line_chars=None)
+    with pytest.raises(CommandFailure):
+        userdel_cmd()
+
+
+@pytest.fixture
+def command_output_and_expected_result():
+    data = """xyz@debian:~$ userdel xyz
+userdel: user bylica is currently used by process 788
+xyz@debian:~$"""
+    result = dict()
+    return data, result
+

--- a/test/unix/test_cmd_userdel.py
+++ b/test/unix/test_cmd_userdel.py
@@ -34,4 +34,3 @@ userdel: user bylica is currently used by process 788
 xyz@debian:~$"""
     result = dict()
     return data, result
-

--- a/test/unix/test_cmd_userdel.py
+++ b/test/unix/test_cmd_userdel.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+"""
+Userdel test module.
+"""
+
+__author__ = 'Agnieszka Bylica'
+__copyright__ = 'Copyright (C) 2018, Nokia'
+__email__ = 'agnieszka.bylica@nokia.com'
+
+
+import pytest
+
+from moler.exceptions import CommandFailure
+from moler.cmd.unix.userdel import Userdel
+
+
+def test_userdel_returns_proper_command_string(buffer_connection):
+    useradd_cmd = Userdel(buffer_connection, user='xyz', prompt=None, new_line_chars=None)
+    assert "useradd xyz" == useradd_cmd.command_string

--- a/test/unix/test_cmd_userdel.py
+++ b/test/unix/test_cmd_userdel.py
@@ -19,6 +19,12 @@ def test_userdel_returns_proper_command_string(buffer_connection):
     assert "userdel xyz" == userdel_cmd.command_string
 
 
+def test_userdel_returns_proper_command_string_with_option(buffer_connection):
+    userdel_cmd = Userdel(connection=buffer_connection.moler_connection, user='xyz', options='-R CHROOT_DIR',
+                          prompt=None, new_line_chars=None)
+    assert "userdel -R CHROOT_DIR xyz" == userdel_cmd.command_string
+
+
 def test_userdel_raises_command_error(buffer_connection):
     command_output, expected_result = command_output_and_expected_result()
     buffer_connection.remote_inject_response([command_output])
@@ -27,10 +33,37 @@ def test_userdel_raises_command_error(buffer_connection):
         userdel_cmd()
 
 
+def test_userdel_raises_command_error_with_help(buffer_connection):
+    command_output, expected_result = command_output_and_expected_result_help()
+    buffer_connection.remote_inject_response([command_output])
+    userdel_cmd = Userdel(connection=buffer_connection.moler_connection, options='-f', prompt=None, new_line_chars=None)
+    with pytest.raises(CommandFailure):
+        userdel_cmd()
+
+
 @pytest.fixture
 def command_output_and_expected_result():
     data = """xyz@debian:~$ userdel xyz
-userdel: user bylica is currently used by process 788
+userdel: invalid option -- 'p'
+xyz@debian:~$"""
+    result = dict()
+    return data, result
+
+
+@pytest.fixture
+def command_output_and_expected_result_help():
+    data = """xyz@debian:~$ userdel -f
+Usage: userdel [options] LOGIN
+
+Options:
+  -f, --force                   force removal of files,
+                                even if not owned by user
+  -h, --help                    display this help message and exit
+  -r, --remove                  remove home directory and mail spool
+  -R, --root CHROOT_DIR         directory to chroot into
+  -Z, --selinux-user            remove any SELinux user mapping for the user
+
+
 xyz@debian:~$"""
     result = dict()
     return data, result

--- a/test/unix/test_cmd_userdel.py
+++ b/test/unix/test_cmd_userdel.py
@@ -28,7 +28,8 @@ def test_userdel_returns_proper_command_string_with_option(buffer_connection):
 def test_userdel_raises_command_error(buffer_connection):
     command_output, expected_result = command_output_and_expected_result()
     buffer_connection.remote_inject_response([command_output])
-    userdel_cmd = Userdel(connection=buffer_connection.moler_connection, user='xyz', prompt=None, new_line_chars=None)
+    userdel_cmd = Userdel(connection=buffer_connection.moler_connection, options='-p', user='tmp_user', prompt=None,
+                          new_line_chars=None)
     with pytest.raises(CommandFailure):
         userdel_cmd()
 
@@ -43,7 +44,7 @@ def test_userdel_raises_command_error_with_help(buffer_connection):
 
 @pytest.fixture
 def command_output_and_expected_result():
-    data = """xyz@debian:~$ userdel xyz
+    data = """xyz@debian:~$ userdel -p tmp_user
 userdel: invalid option -- 'p'
 xyz@debian:~$"""
     result = dict()


### PR DESCRIPTION
Method parse_line_with_force_option is used if someone uses '--force' option to delete user who is currently used by some process. In that case error message is displayed as an information and user is deleted.