### PR TITLE
Allow empty command string

### DIFF
--- a/moler/cmd/commandtextualgeneric.py
+++ b/moler/cmd/commandtextualgeneric.py
@@ -74,7 +74,10 @@ class CommandTextualGeneric(Command):
         :return: Nothing.
         """
         self.__command_string = command_string
-        self._cmd_escaped = re.compile(re.escape(command_string))
+        if command_string is None:
+            self._cmd_escaped = None
+        else:
+            self._cmd_escaped = re.compile(re.escape(command_string))
 
     @staticmethod
     def _calculate_prompt(prompt):

--- a/moler/cmd/unix/enter.py
+++ b/moler/cmd/unix/enter.py
@@ -4,7 +4,7 @@ enter command module.
 """
 
 __author__ = 'Marcin Usielski'
-__copyright__ = 'Copyright (C) 2018, Nokia'
+__copyright__ = 'Copyright (C) 2018-2019, Nokia'
 __email__ = 'marcin.usielski@nokia.com'
 
 
@@ -27,7 +27,7 @@ class Enter(GenericUnixCommand):
         """
         :return: String representation of command to send over connection to device.
         """
-        return " "
+        return ""
 
 
 COMMAND_OUTPUT_ver_execute = """

--- a/moler/command.py
+++ b/moler/command.py
@@ -32,7 +32,7 @@ class Command(ConnectionObserver):
         :param connection: connection used to start CMD and receive its output
         """
         super(Command, self).__init__(connection=connection, runner=runner)
-        self.command_string = ''
+        self.command_string = None
         self.cmd_name = Command.observer_name
 
     def __str__(self):
@@ -45,7 +45,7 @@ class Command(ConnectionObserver):
         # check base class invariants first
         super(Command, self)._validate_start(*args, **kwargs)
         # then what is needed for command
-        if not self.command_string:
+        if self.command_string is None:
             # no chance to start CMD
             raise NoCommandStringProvided(self)
 


### PR DESCRIPTION
Allow empty string as command_string in Command objects (like command Enter).