### PR TITLE
autodetect config type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## moler 1.7.0
+
+### Deprecated
+* `config_type` parameter of `load_config()` is not needed, configuration type is autodetected
+
 ## moler 1.3.0
 
 ### Added

--- a/moler/config/__init__.py
+++ b/moler/config/__init__.py
@@ -64,7 +64,7 @@ def configs_are_same(config_list, config_to_find):
     return False
 
 
-def load_config(config=None, from_env_var=None, **kwargs):
+def load_config(config=None, from_env_var=None, *args, **kwargs):
     """
     Load Moler's configuration from config file.
 

--- a/moler/config/__init__.py
+++ b/moler/config/__init__.py
@@ -87,11 +87,11 @@ def load_config(config=None, from_env_var=None, **kwargs):
         add_devices_only = True
         loaded_config.append(config)
 
-    if not isinstance(config, six.string_types) and not isinstance(config, dict):  # no other format supported yet
+    if config is None and from_env_var is None:
+        raise WrongUsage("Provide either 'config' or 'from_env_var' parameter (none given).")
+    elif not from_env_var and (not isinstance(config, six.string_types) and not isinstance(config, dict)):  # no other format supported yet
         raise WrongUsage("Unsupported config type: '{}'. Allowed are: 'dict' or 'yaml'.".format(type(config)))
     if not config:
-        if not from_env_var:
-            raise WrongUsage("Provide either 'config' or 'from_env_var' parameter (none given).")
         if from_env_var not in os.environ:
             raise KeyError("Environment variable '{}' is not set".format(from_env_var))
         path = os.environ[from_env_var]

--- a/moler/config/__init__.py
+++ b/moler/config/__init__.py
@@ -86,9 +86,10 @@ def load_config(config=None, from_env_var=None, **kwargs):
         add_devices_only = True
         loaded_config.append(config)
 
+    wrong_type_config = not isinstance(config, six.string_types) and not isinstance(config, dict)
     if config is None and from_env_var is None:
         raise WrongUsage("Provide either 'config' or 'from_env_var' parameter (none given).")
-    elif not from_env_var and (not isinstance(config, six.string_types) and not isinstance(config, dict)):  # no other format supported yet
+    elif (not from_env_var and wrong_type_config) or (config and wrong_type_config):
         raise WrongUsage("Unsupported config type: '{}'. Allowed are: 'dict' or 'str' holding config filename (file is in YAML format).".format(type(config)))
     if not config:
         if from_env_var not in os.environ:

--- a/moler/config/__init__.py
+++ b/moler/config/__init__.py
@@ -68,11 +68,10 @@ def load_config(config=None, from_env_var=None, **kwargs):
     """
     Load Moler's configuration from config file.
 
-    config_type parameter is deprached and since 1.4.0 not need to provide. Type of config is autodetecting.
-
+    Load Moler's configuration from config file.
     :param config: either dict or config filename directly provided (overwrites 'from_env_var' if both given).
     :type config: dict or str
-    :param from_env_var: name of environment variable storing config filename
+    :param from_env_var: name of environment variable storing config filename (file is in YAML format)
     :return: None
     """
     global loaded_config

--- a/moler/config/__init__.py
+++ b/moler/config/__init__.py
@@ -89,7 +89,7 @@ def load_config(config=None, from_env_var=None, **kwargs):
     if config is None and from_env_var is None:
         raise WrongUsage("Provide either 'config' or 'from_env_var' parameter (none given).")
     elif not from_env_var and (not isinstance(config, six.string_types) and not isinstance(config, dict)):  # no other format supported yet
-        raise WrongUsage("Unsupported config type: '{}'. Allowed are: 'dict' or 'yaml'.".format(type(config)))
+        raise WrongUsage("Unsupported config type: '{}'. Allowed are: 'dict' or 'str' holding config filename (file is in YAML format).".format(type(config)))
     if not config:
         if from_env_var not in os.environ:
             raise KeyError("Environment variable '{}' is not set".format(from_env_var))

--- a/moler/config/__init__.py
+++ b/moler/config/__init__.py
@@ -64,13 +64,15 @@ def configs_are_same(config_list, config_to_find):
     return False
 
 
-def load_config(config=None, from_env_var=None, config_type='yaml'):
+def load_config(config=None, from_env_var=None, **kwargs):
     """
-    Load Moler's configuration from config file
+    Load Moler's configuration from config file.
 
-    :param config: either dict or config filename directly provided (overwrites 'from_env_var' if both given)
+    config_type parameter is deprached and since 1.4.0 not need to provide. Type of config is autodetecting.
+
+    :param config: either dict or config filename directly provided (overwrites 'from_env_var' if both given).
+    :type config: dict or str
     :param from_env_var: name of environment variable storing config filename
-    :param config_type: 'dict' ('config' param is dict) or 'yaml' ('config' is filename of file with YAML content)
     :return: None
     """
     global loaded_config
@@ -85,8 +87,8 @@ def load_config(config=None, from_env_var=None, config_type='yaml'):
         add_devices_only = True
         loaded_config.append(config)
 
-    if (config_type != 'dict') and (config_type != 'yaml'):  # no other format supported yet
-        raise WrongUsage("Unsupported config_type: '{}'. Allowed are: 'dict' or 'yaml'.".format(config_type))
+    if not isinstance(config, six.string_types) and not isinstance(config, dict):  # no other format supported yet
+        raise WrongUsage("Unsupported config type: '{}'. Allowed are: 'dict' or 'yaml'.".format(type(config)))
     if not config:
         if not from_env_var:
             raise WrongUsage("Provide either 'config' or 'from_env_var' parameter (none given).")
@@ -94,12 +96,9 @@ def load_config(config=None, from_env_var=None, config_type='yaml'):
             raise KeyError("Environment variable '{}' is not set".format(from_env_var))
         path = os.environ[from_env_var]
         config = read_yaml_configfile(path)
-    elif config_type == 'yaml':
-        assert isinstance(config, six.string_types)
+    elif isinstance(config, six.string_types):
         path = config
         config = read_yaml_configfile(path)
-    elif config_type == 'dict':
-        assert isinstance(config, dict)
     # TODO: check schema
     if add_devices_only is False:
         load_logger_from_config(config)

--- a/test/device/test_device_configuration.py
+++ b/test/device/test_device_configuration.py
@@ -446,7 +446,7 @@ def test_cannot_load_config_from_when_path_or_from_env_var_not_provide(moler_con
     assert "Provide either 'config' or 'from_env_var' parameter (none given)" in str(err.value)
 
 
-@pytest.mark.parametrize('params', [{'config': (), 'config_type': "wrong_type"},
+@pytest.mark.parametrize('params', [{'config': (), 'config_type': "wrong_type"},  # test backward compatibility
                                     {'config': ()}])
 def test_cannot_load_config_from_when_wrong_config_type_provided(moler_config, params):
     with pytest.raises(WrongUsage) as err:

--- a/test/device/test_device_configuration.py
+++ b/test/device/test_device_configuration.py
@@ -446,11 +446,13 @@ def test_cannot_load_config_from_when_path_or_from_env_var_not_provide(moler_con
     assert "Provide either 'config' or 'from_env_var' parameter (none given)" in str(err.value)
 
 
-def test_cannot_load_config_from_when_wrong_config_type_provided(moler_config):
+@pytest.mark.parametrize('params', [{'config': (), 'config_type': "wrong_type"},
+                                    {'config': ()}])
+def test_cannot_load_config_from_when_wrong_config_type_provided(moler_config, params):
     with pytest.raises(WrongUsage) as err:
-        moler_config.load_config(config_type="wrong_type")
+        moler_config.load_config(**params)
 
-    assert "Unsupported config_type" in str(err.value)
+    assert "Unsupported config type" in str(err.value)
 
 
 def test_can_select_device_loaded_from_config_dict(moler_config, device_factory):

--- a/test/device/test_device_configuration.py
+++ b/test/device/test_device_configuration.py
@@ -447,6 +447,7 @@ def test_cannot_load_config_from_when_path_or_from_env_var_not_provide(moler_con
 
 
 @pytest.mark.parametrize('params', [{'config': (), 'config_type': "wrong_type"},  # test backward compatibility
+                                    {'from_env_var': 'AAA', 'config': [1, 2]},
                                     {'config': ()}])
 def test_cannot_load_config_from_when_wrong_config_type_provided(moler_config, params):
     with pytest.raises(WrongUsage) as err:

--- a/test/test_connection_configuration.py
+++ b/test/test_connection_configuration.py
@@ -107,7 +107,7 @@ def test_can_select_connection_loaded_from_config_file(moler_config):
     assert conn.port == 2345
 
 
-@pytest.mark.parametrize('params', [{'from_env_var': "MOLER_CONFIG", 'config_type': "yaml"},
+@pytest.mark.parametrize('params', [{'from_env_var': "MOLER_CONFIG", 'config_type': "yaml"},  # test backward compatibility
                                     {'from_env_var': "MOLER_CONFIG"}])
 def test_can_select_connection_loaded_from_env_variable(moler_config, monkeypatch, params):
     from moler.connection_factory import get_connection
@@ -125,7 +125,7 @@ def test_can_select_connection_loaded_from_env_variable(moler_config, monkeypatc
 
 @pytest.mark.parametrize('params', [{'config': {'NAMED_CONNECTIONS': {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
                                                 'IO_TYPES': {'default_variant': {'tcp': 'threaded'}}},
-                                     'config_type': "dict"},
+                                     'config_type': "dict"},  # test backward compatibility
                                     {'config': {'NAMED_CONNECTIONS': {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
                                                 'IO_TYPES': {'default_variant': {'tcp': 'threaded'}}}}])
 def test_can_select_connection_loaded_from_dict(moler_config, params):

--- a/test/test_connection_configuration.py
+++ b/test/test_connection_configuration.py
@@ -128,10 +128,27 @@ def test_can_select_connection_loaded_from_env_variable(moler_config, monkeypatc
                                      'config_type': "dict"},  # test backward compatibility
                                     {'config': {'NAMED_CONNECTIONS': {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
                                                 'IO_TYPES': {'default_variant': {'tcp': 'threaded'}}}}])
-def test_can_select_connection_loaded_from_dict(moler_config, params):
+def test_can_select_connection_loaded_from_dict_as_keyword_args(moler_config, params):
     from moler.connection_factory import get_connection
 
     moler_config.load_config(**params)
+
+    conn = get_connection(name='www_server_1')
+    assert conn.__module__ == 'moler.io.raw.tcp'
+    assert conn.__class__.__name__ == 'ThreadedTcp'
+    assert conn.host == 'localhost'
+    assert conn.port == 2344
+
+
+@pytest.mark.parametrize('args', [({'NAMED_CONNECTIONS': {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
+                                    'IO_TYPES': {'default_variant': {'tcp': 'threaded'}}},
+                                   None, 'dict'),  # test backward compatibility
+                                  ({'NAMED_CONNECTIONS': {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
+                                    'IO_TYPES': {'default_variant': {'tcp': 'threaded'}}},)])
+def test_can_select_connection_loaded_from_dict_as_positional_args(moler_config, args):
+    from moler.connection_factory import get_connection
+
+    moler_config.load_config(*args)
 
     conn = get_connection(name='www_server_1')
     assert conn.__module__ == 'moler.io.raw.tcp'

--- a/test/test_connection_configuration.py
+++ b/test/test_connection_configuration.py
@@ -107,12 +107,14 @@ def test_can_select_connection_loaded_from_config_file(moler_config):
     assert conn.port == 2345
 
 
-def test_can_select_connection_loaded_from_env_variable(moler_config, monkeypatch):
+@pytest.mark.parametrize('params', [{'from_env_var': "MOLER_CONFIG", 'config_type': "yaml"},
+                                    {'from_env_var': "MOLER_CONFIG"}])
+def test_can_select_connection_loaded_from_env_variable(moler_config, monkeypatch, params):
     from moler.connection_factory import get_connection
 
     conn_config = os.path.join(os.path.dirname(__file__), "resources", "www_servers_connections.yml")
     monkeypatch.setitem(os.environ, 'MOLER_CONFIG', conn_config)
-    moler_config.load_config(from_env_var="MOLER_CONFIG", config_type='yaml')
+    moler_config.load_config(**params)
 
     conn = get_connection(name='www_server_1')
     assert conn.__module__ == 'moler.io.raw.tcp'
@@ -121,14 +123,15 @@ def test_can_select_connection_loaded_from_env_variable(moler_config, monkeypatc
     assert conn.port == 2345
 
 
-def test_can_select_connection_loaded_from_dict(moler_config):
+@pytest.mark.parametrize('params', [{'config': {'NAMED_CONNECTIONS': {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
+                                                'IO_TYPES': {'default_variant': {'tcp': 'threaded'}}},
+                                     'config_type': "dict"},
+                                    {'config': {'NAMED_CONNECTIONS': {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
+                                                'IO_TYPES': {'default_variant': {'tcp': 'threaded'}}}}])
+def test_can_select_connection_loaded_from_dict(moler_config, params):
     from moler.connection_factory import get_connection
 
-    configuration_in_dict = {'NAMED_CONNECTIONS':
-                                 {'www_server_1': {'io_type': 'tcp', 'host': 'localhost', 'port': 2344}},
-                             'IO_TYPES':
-                                 {'default_variant': {'tcp': 'threaded'}}}
-    moler_config.load_config(config=configuration_in_dict, config_type='dict')
+    moler_config.load_config(**params)
 
     conn = get_connection(name='www_server_1')
     assert conn.__module__ == 'moler.io.raw.tcp'


### PR DESCRIPTION
looks like `config_type` parameter in `load_config()` is redundant. I've add `*args` and `**kwargs` for backward compatibility.