### PR TITLE
Iperf v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
+## moler 1.4.0
+
+### Changed
+* connection name returned by iperf2 uses "port@host" format to not confuse on IPv6 (fd00::1:0:5901 -> 5901@fd00::1:0)
+
+
 ## moler 1.3.1
 
 ### Added
-* option to disable log every occurrence for events
-* backward compatibility for load_device_from_config
+* possibility to enable/disable logging each occurrence of event
+* backward compatibility for load_device_from_config()
 
 ### Fixed
-* correct device remove functionality functionality
+* device closing (dev.remove() method) fails if device was already closed
 
 
 ## moler 1.3.0

--- a/moler/event.py
+++ b/moler/event.py
@@ -144,7 +144,7 @@ class Event(ConnectionObserver):
 
     def _log_occurred(self):
         """
-        Logs info about notify when callback is not define.
+        Logs info about notify when callback is not defined.
 
         :return: None
         """

--- a/test/cmd/unix/test_cmd_iperf2.py
+++ b/test/cmd/unix/test_cmd_iperf2.py
@@ -58,12 +58,40 @@ def test_iperf_stores_connections_as_host_port_tuple_for_local_and_remote(buffer
                               **iperf2.COMMAND_KWARGS_bidirectional_udp_server)
     iperf_cmd()
     stored_connections = iperf_cmd.result()['CONNECTIONS'].keys()
+    #      local port@host      remote port@host
+    assert len(stored_connections) == 4
+    assert ('56262@192.168.0.10', '5016@192.168.0.12') in stored_connections
+    assert ('47384@192.168.0.12', '5016@192.168.0.10') in stored_connections
+    assert ('192.168.0.10', '5016@192.168.0.12') in stored_connections
+    assert ('192.168.0.12', '5016@192.168.0.10') in stored_connections
+
+
+def test_iperf_stores_connections_as_port_at_host_tuple_for_local_and_remote(buffer_connection):
+    from moler.cmd.unix import iperf2
+    buffer_connection.remote_inject_response([iperf2.COMMAND_OUTPUT_bidirectional_udp_server])
+    iperf_cmd = iperf2.Iperf2(connection=buffer_connection.moler_connection,
+                              **iperf2.COMMAND_KWARGS_bidirectional_udp_server)
+    iperf_cmd()
+    stored_connections = iperf_cmd.result()['CONNECTIONS'].keys()
     #        local host:port      remote host:port
     assert len(stored_connections) == 4
-    assert ('192.168.0.10:56262', '192.168.0.12:5016') in stored_connections
-    assert ('192.168.0.12:47384', '192.168.0.10:5016') in stored_connections
-    assert ('192.168.0.10', '192.168.0.12:5016') in stored_connections
-    assert ('192.168.0.12', '192.168.0.10:5016') in stored_connections
+    assert ('56262@192.168.0.10', '5016@192.168.0.12') in stored_connections
+    assert ('47384@192.168.0.12', '5016@192.168.0.10') in stored_connections
+    assert ('192.168.0.10', '5016@192.168.0.12') in stored_connections
+    assert ('192.168.0.12', '5016@192.168.0.10') in stored_connections
+
+
+def test_iperf_stores_ipv6_connections_as_port_at_host_tuple_for_local_and_remote(buffer_connection):
+    from moler.cmd.unix import iperf2
+    buffer_connection.remote_inject_response([iperf2.COMMAND_OUTPUT_tcp_ipv6_client])
+    iperf_cmd = iperf2.Iperf2(connection=buffer_connection.moler_connection,
+                              **iperf2.COMMAND_KWARGS_tcp_ipv6_client)
+    iperf_cmd()
+    stored_connections = iperf_cmd.result()['CONNECTIONS'].keys()
+    #      local port@host      remote port@host
+    assert len(stored_connections) == 2
+    assert ("49597@fd00::2:0", "5901@fd00::1:0") in stored_connections
+    assert ("fd00::2:0", "5901@fd00::1:0") in stored_connections
 
 
 def test_iperf_creates_summary_connection_for_parallel_testing(buffer_connection):
@@ -75,8 +103,8 @@ def test_iperf_creates_summary_connection_for_parallel_testing(buffer_connection
     stored_connections = iperf_cmd.result()['CONNECTIONS'].keys()
     #        local host:port      remote host:port
     assert len(stored_connections) == 22
-    assert ('192.168.0.102:multiport', '192.168.0.100:5001') in stored_connections  # summary
-    assert ('192.168.0.102', '192.168.0.100:5001') in stored_connections  # result
+    assert ('multiport@192.168.0.102', '5001@192.168.0.100') in stored_connections  # summary
+    assert ('192.168.0.102', '5001@192.168.0.100') in stored_connections  # result
 
 
 def test_iperf_correctly_parses_bidirectional_udp_client_output(buffer_connection):
@@ -113,6 +141,24 @@ def test_iperf_correctly_parses_basic_tcp_client_output(buffer_connection):
                               **iperf2.COMMAND_KWARGS_basic_client)
     res = iperf_cmd()
     assert res == iperf2.COMMAND_RESULT_basic_client
+
+
+def test_iperf_correctly_parses_tcp_ipv6_client_output(buffer_connection):
+    from moler.cmd.unix import iperf2
+    buffer_connection.remote_inject_response([iperf2.COMMAND_OUTPUT_tcp_ipv6_client])
+    iperf_cmd = iperf2.Iperf2(connection=buffer_connection.moler_connection,
+                              **iperf2.COMMAND_KWARGS_tcp_ipv6_client)
+    res = iperf_cmd()
+    assert res == iperf2.COMMAND_RESULT_tcp_ipv6_client
+
+
+def test_iperf_correctly_parses_tcp_ipv6_server_output(buffer_connection):
+    from moler.cmd.unix import iperf2
+    buffer_connection.remote_inject_response([iperf2.COMMAND_OUTPUT_tcp_ipv6_server])
+    iperf_cmd = iperf2.Iperf2(connection=buffer_connection.moler_connection,
+                              **iperf2.COMMAND_KWARGS_tcp_ipv6_server)
+    res = iperf_cmd()
+    assert res == iperf2.COMMAND_RESULT_tcp_ipv6_server
 
 
 def test_iperf_correctly_parses_multiconnection_tcp_client_output(buffer_connection):

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""
+Testing connection observer runner
+"""
+
+__author__ = 'Grzegorz Latuszek'
+__copyright__ = 'Copyright (C) 2019, Nokia'
+__email__ = 'grzegorz.latuszek@nokia.com'
+
+import time
+import mock
+
+import pytest
+from moler.observable_connection import ObservableConnection
+from moler.connection_observer import ConnectionObserver
+from moler.event import Event
+from moler.command import Command
+
+
+def test_can_use_runner_as_context_manager(connection_observer,
+                                           observer_runner):
+    original_shutdown = observer_runner.__class__.shutdown
+    shutdown_call_params = []
+
+    def proxy_shutdown(self):
+        shutdown_call_params.append(self)
+        original_shutdown(self)
+
+    with mock.patch.object(observer_runner.__class__, "shutdown", proxy_shutdown):
+        with observer_runner:
+            connection_observer.start_time = time.time()  # must start observer lifetime before runner.submit()
+            observer_runner.submit(connection_observer)
+
+    assert observer_runner in shutdown_call_params
+
+
+def test_time_out_observer_can_set_proper_exception_inside_observer(conn_observer,
+                                                                    observer_runner):
+    from moler.runner import time_out_observer
+    from moler.exceptions import CommandTimeout
+    from moler.exceptions import ConnectionObserverTimeout
+
+    if conn_observer.is_command():
+        expected_timeout_class = CommandTimeout
+    else:
+        expected_timeout_class = ConnectionObserverTimeout
+
+    with observer_runner:
+        conn_observer.start_time = time.time()
+        observer_runner.submit(conn_observer)
+        time_out_observer(conn_observer, timeout=2.3, passed_time=2.32, runner_logger=mock.MagicMock())
+
+    assert conn_observer.done()
+    with pytest.raises(expected_timeout_class):
+        conn_observer.result()
+
+
+def test_time_out_observer_sets_exception_inside_observer_before_calling_on_timeout(conn_observer,
+                                                                                    observer_runner):
+    from moler.runner import time_out_observer
+    from moler.exceptions import ConnectionObserverTimeout
+
+    def on_timeout_handler(self):
+        with pytest.raises(ConnectionObserverTimeout):
+            self.result()
+
+    with mock.patch.object(conn_observer.__class__, "on_timeout", on_timeout_handler):
+        with observer_runner:
+            conn_observer.start_time = time.time()
+            observer_runner.submit(conn_observer)
+            time_out_observer(conn_observer, timeout=2.3, passed_time=2.32, runner_logger=mock.MagicMock())
+
+
+# --------------------------- resources ---------------------------
+
+
+@pytest.fixture()
+def observer_runner():
+    from moler.runner import ThreadPoolExecutorRunner
+    runner = ThreadPoolExecutorRunner()
+    return runner
+
+
+class NetworkDownDetector(ConnectionObserver):
+    def __init__(self, connection=None, runner=None):
+        super(NetworkDownDetector, self).__init__(connection=connection, runner=runner)
+        self.all_data_received = []
+
+    def data_received(self, data):
+        """
+        Awaiting change like:
+        64 bytes from 10.0.2.15: icmp_req=3 ttl=64 time=0.045 ms
+        ping: sendmsg: Network is unreachable
+        """
+        self.all_data_received.append(data)
+        if not self.done():
+            if "Network is unreachable" in data:
+                when_detected = time.time()
+                self.set_result(result=when_detected)
+
+
+class MyEvent(Event):
+    def data_received(self, data):
+        pass
+
+
+class MyCommand(Command):
+    def __init__(self, connection=None, runner=None):
+        super(MyCommand, self).__init__(connection=connection, runner=runner)
+        self.command_string = 'hi'
+
+    def data_received(self, data):
+        pass
+
+
+@pytest.fixture()
+def connection_observer():
+    moler_conn = ObservableConnection()
+    observer = NetworkDownDetector(connection=moler_conn)
+    return observer
+
+
+@pytest.fixture(params=['generic_observer', 'event', 'command'])
+def conn_observer(request):
+    moler_conn = ObservableConnection(how2send=mock.MagicMock())
+    if request.param == 'generic_observer':
+        observer = NetworkDownDetector(connection=moler_conn)
+    elif request.param == 'event':
+        observer = MyEvent(connection=moler_conn)
+    elif request.param == 'command':
+        observer = MyCommand(connection=moler_conn)
+    return observer

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -136,7 +136,7 @@ def test_CancellableFuture_can_force_cancel_of_embedded_future():
         c_future.cancel(no_wait=False)
     time.sleep(0.1)
     assert "state=finished" in str(connection_observer_future)
-    assert "Failed to stop thread-running function within 0.2 sec" in exc.value
+    assert "Failed to stop thread-running function within 0.2 sec" in str(exc.value)
 
 
 def test_ThreadPoolExecutorRunner_logs_about_reused_executor():

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -71,6 +71,24 @@ def test_time_out_observer_sets_exception_inside_observer_before_calling_on_time
             time_out_observer(conn_observer, timeout=2.3, passed_time=2.32, runner_logger=mock.MagicMock())
 
 
+def test_runner_doesnt_impact_unrised_observer_exception_while_taking_observer_result(connection_observer,
+                                                                                      observer_runner):
+    from moler.runner import time_out_observer, result_for_runners
+    from moler.exceptions import ConnectionObserverTimeout
+
+    with observer_runner:
+        connection_observer.start_time = time.time()  # must start observer lifetime before runner.submit()
+        observer_runner.submit(connection_observer)
+        time_out_observer(connection_observer, timeout=2.3, passed_time=2.32, runner_logger=mock.MagicMock())
+
+    timeout = connection_observer._exception
+    assert timeout in ConnectionObserver._not_raised_exceptions
+    try:
+        result_for_runners(connection_observer)
+    except ConnectionObserverTimeout as timeout:
+        assert timeout in ConnectionObserver._not_raised_exceptions
+
+
 # --------------------------- resources ---------------------------
 
 


### PR DESCRIPTION
connection name returned by iperf2 uses "port@host" format to not confuse on IPv6 

moler 1.3.1 used "host:port" format which is confusing in case of IPv6:
`fd00::1:0:5901` - is it IP:port  or just IP?
`5901@fd00::1:0` - is clear