### PR TITLE
Uptime regex fix

### DIFF
--- a/moler/cmd/unix/uptime.py
+++ b/moler/cmd/unix/uptime.py
@@ -75,7 +75,7 @@ class Uptime(GenericUnixCommand):
 
     # 137 day(s), 19:07
     # 3 days  2:14
-    _re_days = re.compile(r"(?P<DAYS>\d+) day(.*),\s+(?P<HRS>\d+):(?P<MINS>\d+)")
+    _re_days = re.compile(r"(?P<DAYS>\d+) day(.*),?\s+(?P<HRS>\d+):(?P<MINS>\d+)")
 
     # 2 day(s), 3 min
     _re_days_minutes = re.compile(r"(?P<DAYS>\d+) day(.*),\s+(?P<MINS>\d+)\s+min")
@@ -137,7 +137,7 @@ COMMAND_KWARGS_days_hours_minutes = {}
 
 COMMAND_RESULT_days_hours_minutes = {
     "UPTIME": '3 days  2:14',
-    "UPTIME_SECONDS": 8040,
+    "UPTIME_SECONDS": 267240,
     "USERS": 29
 }
 

--- a/test/cmd/unix/test_cmd_uptime.py
+++ b/test/cmd/unix/test_cmd_uptime.py
@@ -66,7 +66,7 @@ host:~ #"""
 
     result = {
         "UPTIME": '3 days  2:14',
-        "UPTIME_SECONDS": 8040,
+        "UPTIME_SECONDS": 267240,
         "USERS": 29,
     }
     return data, result

--- a/test/integration/test_many_commands_connection.py
+++ b/test/integration/test_many_commands_connection.py
@@ -123,7 +123,7 @@ host:~ # """)
     result = (
         {
             "UPTIME": '3 days  2:14',
-            "UPTIME_SECONDS": 8040,
+            "UPTIME_SECONDS": 267240,
             "USERS": 29,
         },
         {
@@ -146,12 +146,12 @@ host:~ # """)
     result = (
         {
             "UPTIME": '3 days  2:14',
-            "UPTIME_SECONDS": 8040,
+            "UPTIME_SECONDS": 267240,
             "USERS": 29,
         },
         {
             "UPTIME": '3 days  2:15',
-            "UPTIME_SECONDS": 8100,
+            "UPTIME_SECONDS": 267300,
             "USERS": 8,
         }
     )


### PR DESCRIPTION
Previous regex didn't catch _'3 days  2:14'_ (as it didn't have comma) therefore bad seconds calculation.
