### PR TITLE
Predictable adb shell prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## moler 1.11.0
+
+### Improved
+* Allow AdbRemote device to have expected_prompt generated from serial_number of Android device
+
 ## moler 1.10.0
 
 ### Improved

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019, Nokia'
 author = 'Nokia'
 
 # The short X.Y version
-version = '1.10.0'
+version = '1.11.0'
 # The full version, including alpha/beta/rc tags
 release = 'stable'
 

--- a/moler/cmd/adb/adb_shell.py
+++ b/moler/cmd/adb/adb_shell.py
@@ -42,7 +42,7 @@ class AdbShell(CommandChangingPrompt):
          then leave it None.
         :param prompt_from_serial_number: Generate expected_prompt from serial_number.
         """
-        if prompt_from_serial_number:
+        if prompt_from_serial_number and (not expected_prompt):
             if not prompt_after_login:
                 prompt_after_login = self._re_default_prompt
             if serial_number and (not set_prompt):

--- a/moler/cmd/adb/adb_shell.py
+++ b/moler/cmd/adb/adb_shell.py
@@ -129,9 +129,9 @@ COMMAND_KWARGS_selected_device = {
 
 COMMAND_RESULT_selected_device = {}
 
-COMMAND_OUTPUT_serial_number_generated_prompt = """
+COMMAND_OUTPUT_serial_number_generated_prompt = r"""
 xyz@debian ~$ adb -s f57e6b77 shell
-shell@adbhost:/ $ 
+shell@adbhost:/ $
 shell@adbhost:/ $ export PS1="adb_shell@f57e6b77 \$ "
 adb_shell@f57e6b77 $ """
 

--- a/moler/cmd/adb/adb_shell.py
+++ b/moler/cmd/adb/adb_shell.py
@@ -20,7 +20,8 @@ class AdbShell(CommandChangingPrompt):
 
     def __init__(self, connection, serial_number=None, prompt=None, expected_prompt=None,
                  newline_chars=None, target_newline="\n", runner=None, set_timeout=None,
-                 allowed_newline_after_prompt=False, set_prompt=None, prompt_after_login=None):
+                 allowed_newline_after_prompt=False, set_prompt=None, prompt_after_login=None,
+                 prompt_from_serial_number=False):
         """
         Moler class of Unix command adb shell.
 
@@ -38,7 +39,14 @@ class AdbShell(CommandChangingPrompt):
         :param set_prompt: Command to set prompt after adb shell success.
         :param prompt_after_login: prompt after login before send export PS1. If you do not change prompt exporting PS1
          then leave it None.
+        :param prompt_from_serial_number: Generate expected_prompt from serial_number.
         """
+        if prompt_from_serial_number:
+            if not prompt_after_login:
+                prompt_after_login = self._re_default_prompt
+            if serial_number and (not set_prompt):
+                set_prompt = r'export PS1="adb_shell@{} \$ "'.format(serial_number)
+                expected_prompt = re.compile(r'^adb_shell@{} \$'.format(serial_number))
         super(AdbShell, self).__init__(connection=connection, prompt=prompt, newline_chars=newline_chars,
                                        runner=runner, expected_prompt=expected_prompt, set_timeout=set_timeout,
                                        set_prompt=set_prompt, target_newline=target_newline,
@@ -119,3 +127,16 @@ COMMAND_KWARGS_selected_device = {
 }
 
 COMMAND_RESULT_selected_device = {}
+
+COMMAND_OUTPUT_serial_number_generated_prompt = """
+xyz@debian ~$ adb -s f57e6b77 shell
+shell@adbhost:/ $ 
+shell@adbhost:/ $ export PS1="adb_shell@f57e6b77 \$ "
+adb_shell@f57e6b77 $ """
+
+COMMAND_KWARGS_serial_number_generated_prompt = {
+    'serial_number': 'f57e6b77',
+    'prompt_from_serial_number': True
+}
+
+COMMAND_RESULT_serial_number_generated_prompt = {}

--- a/moler/cmd/adb/adb_shell.py
+++ b/moler/cmd/adb/adb_shell.py
@@ -17,6 +17,7 @@ from moler.helpers import remove_all_known_special_chars
 
 
 class AdbShell(CommandChangingPrompt):
+    re_generated_prompt = r'^adb_shell@{} \$'
 
     def __init__(self, connection, serial_number=None, prompt=None, expected_prompt=None,
                  newline_chars=None, target_newline="\n", runner=None, set_timeout=None,
@@ -46,7 +47,7 @@ class AdbShell(CommandChangingPrompt):
                 prompt_after_login = self._re_default_prompt
             if serial_number and (not set_prompt):
                 set_prompt = r'export PS1="adb_shell@{} \$ "'.format(serial_number)
-                expected_prompt = re.compile(r'^adb_shell@{} \$'.format(serial_number))
+                expected_prompt = re.compile(self.re_generated_prompt.format(serial_number))
         super(AdbShell, self).__init__(connection=connection, prompt=prompt, newline_chars=newline_chars,
                                        runner=runner, expected_prompt=expected_prompt, set_timeout=set_timeout,
                                        set_prompt=set_prompt, target_newline=target_newline,

--- a/moler/cmd/commandchangingprompt.py
+++ b/moler/cmd/commandchangingprompt.py
@@ -182,7 +182,8 @@ class CommandChangingPrompt(CommandTextualGeneric):
         :param line: Line from device
         :return: Match object or None
         """
-        return self._regex_helper.search_compiled(self._re_expected_prompt, line)
+        found = self._regex_helper.search_compiled(self._re_expected_prompt, line)
+        return found
 
     def _is_prompt_after_login(self, line):
         """
@@ -191,7 +192,8 @@ class CommandChangingPrompt(CommandTextualGeneric):
         :param line: Line from device
         :return: Match object or None
         """
-        return self._regex_helper.search_compiled(self._re_prompt_after_login, line)
+        found = self._regex_helper.search_compiled(self._re_prompt_after_login, line)
+        return found
 
     def _all_after_login_settings_sent(self):
         """

--- a/moler/device/adbremote.py
+++ b/moler/device/adbremote.py
@@ -15,6 +15,7 @@ from moler.device.textualdevice import TextualDevice
 # from moler.device.proxy_pc import ProxyPc  # TODO: allow jumping towards ADB_REMOTE via proxy-pc
 from moler.device.unixlocal import UnixLocal
 from moler.device.unixremote import UnixRemote
+from moler.cmd.adb.adb_shell import AdbShell
 from moler.helpers import call_base_class_method_with_same_name, mark_to_call_base_class_method_with_same_name
 
 
@@ -82,10 +83,11 @@ class AdbRemote(UnixRemote):
                     AdbRemote.adb_shell: {  # to
                         "execute_command": "adb_shell",
                         "command_params": {  # with parameters
-                            "target_newline": "\n"
+                            "target_newline": "\n",
+                            "prompt_from_serial_number": True,
                         },
                         "required_command_params": [
-                            "expected_prompt"  # TODO: if not required then we depend on default-unix-prompt regexp
+                            "serial_number",
                         ]
                     },
                 },
@@ -171,7 +173,8 @@ class AdbRemote(UnixRemote):
         hops_config = self._configurations[TextualDevice.connection_hops]
         cfg_ux2adb = hops_config[UnixRemote.unix_remote][AdbRemote.adb_shell]
         cfg_adb2adbroot = hops_config[AdbRemote.adb_shell][AdbRemote.adb_shell_root]
-        adb_shell_prompt = cfg_ux2adb["command_params"]["expected_prompt"]
+        adb_shell_cmd_params = cfg_ux2adb["command_params"]
+        adb_shell_prompt = self._get_adb_shell_prompt(adb_shell_cmd_params)
         adb_shell_root_prompt = cfg_adb2adbroot["command_params"]["expected_prompt"]
         if adb_shell_root_prompt is None:
             if adb_shell_prompt.endswith("$"):
@@ -188,6 +191,26 @@ class AdbRemote(UnixRemote):
             AdbRemote.adb_shell_root: adb_shell_root_prompt,
         }
         return state_prompts
+
+    @property
+    def _serial_number(self):
+        """
+        Retrieve serial_number based on required parameter of state machine.
+
+        :return: serial_number.
+        """
+        hops_config = self._configurations[TextualDevice.connection_hops]
+        cfg_ux2adb = hops_config[UnixRemote.unix_remote][AdbRemote.adb_shell]
+        serial_number = cfg_ux2adb["command_params"]["serial_number"]
+        return serial_number
+
+    def _get_adb_shell_prompt(self, adb_shell_cmd_params):
+        if 'expected_prompt' in adb_shell_cmd_params:
+            adb_shell_prompt = adb_shell_cmd_params["expected_prompt"]
+        else:
+            # adb_shell@f57e6b77 $
+            adb_shell_prompt = AdbShell.re_generated_prompt.format(self._serial_number)
+        return adb_shell_prompt
 
     @mark_to_call_base_class_method_with_same_name
     def _prepare_newline_chars_without_proxy_pc(self):
@@ -282,7 +305,7 @@ class AdbRemote(UnixRemote):
         # copy prompt for ADB_SHELL_ROOT/exit from UNIX_REMOTE/adb shell
         cfg_ux2adb = hops_config[UnixRemote.unix_remote][AdbRemote.adb_shell]
         cfg_adbroot2adb = hops_config[AdbRemote.adb_shell_root][AdbRemote.adb_shell]
-        adb_shell_prompt = cfg_ux2adb["command_params"]["expected_prompt"]
+        adb_shell_prompt = self._get_adb_shell_prompt(cfg_ux2adb["command_params"])
         cfg_adbroot2adb["command_params"]["expected_prompt"] = adb_shell_prompt
 
         cfg_adb2adbroot = hops_config[AdbRemote.adb_shell][AdbRemote.adb_shell_root]

--- a/moler/device/adbremote.py
+++ b/moler/device/adbremote.py
@@ -205,9 +205,10 @@ class AdbRemote(UnixRemote):
         return serial_number
 
     def _get_adb_shell_prompt(self, adb_shell_cmd_params):
+        adb_shell_prompt = None
         if 'expected_prompt' in adb_shell_cmd_params:
             adb_shell_prompt = adb_shell_cmd_params["expected_prompt"]
-        else:
+        if not adb_shell_prompt:
             # adb_shell@f57e6b77 $
             adb_shell_prompt = AdbShell.re_generated_prompt.format(self._serial_number)
         return adb_shell_prompt

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with io.open(join(here, 'requirements.txt'), encoding='utf-8') as f:
 
 setup(
     name='moler',  # Required
-    version='1.10.0',  # Required
+    version='1.11.0',  # Required
     description='Moler is library to help in building automated tests',  # Required
     long_description=long_description,  # Optional
     long_description_content_type='text/markdown',  # Optional (see note above)

--- a/test/cmd/adb/test_cmd_adb_shell.py
+++ b/test/cmd/adb/test_cmd_adb_shell.py
@@ -37,7 +37,7 @@ def test_calling_adb_shell_raises_CommandFailure_with_error_msg_from_cause(buffe
     from moler.cmd.adb import adb_shell
     buffer_connection.remote_inject_response(["adb shell\n{}\nxyz@debian ~$ ".format(cause)])
     cmd_adb_shell = adb_shell.AdbShell(connection=buffer_connection.moler_connection,
-                                       expected_prompt= r'shell@adbhost:/ \$')
+                                       expected_prompt=r'shell@adbhost:/ \$')
     with pytest.raises(CommandFailure) as error:
         cmd_adb_shell()
     assert "failed with >>Found error regex in line '{}'<<".format(cause) in str(error.value)
@@ -47,5 +47,23 @@ def test_adb_shell_displays_expected_prompt_in_str_conversion(buffer_connection)
     from moler.cmd.adb import adb_shell
 
     cmd_adb_shell = adb_shell.AdbShell(connection=buffer_connection.moler_connection,
-                                       expected_prompt= r'shell@adbhost:/ \$')
+                                       expected_prompt=r'shell@adbhost:/ \$')
     assert r"expected_prompt_regex:r'shell@adbhost:/ \$'" in str(cmd_adb_shell)
+
+
+def test_adb_shell_can_generate_serial_number_based_prompt(buffer_connection):
+    from moler.cmd.adb import adb_shell
+
+    cmd_adb_shell = adb_shell.AdbShell(connection=buffer_connection.moler_connection,
+                                       serial_number='f57e6b77',
+                                       prompt_from_serial_number=True)
+    assert r"expected_prompt_regex:r'^adb_shell@f57e6b77 \$'" in str(cmd_adb_shell)
+
+
+def test_adb_shell_finishes_on_serial_number_generated_prompt(buffer_connection):
+    from moler.cmd.adb import adb_shell
+    cmd_adb_shell = adb_shell.AdbShell(connection=buffer_connection.moler_connection,
+                                       **adb_shell.COMMAND_KWARGS_serial_number_generated_prompt)
+    buffer_connection.remote_inject_response([adb_shell.COMMAND_OUTPUT_serial_number_generated_prompt])
+    result = cmd_adb_shell()
+    assert result == adb_shell.COMMAND_RESULT_serial_number_generated_prompt

--- a/test/device/test_SM_adb_remote.py
+++ b/test/device/test_SM_adb_remote.py
@@ -27,14 +27,16 @@ def adb_remote_output():
         "UNIX_REMOTE": {
             'exit': 'moler_bash#',
             'su': 'remote_root_prompt',
-            'adb -s f57e6b77 shell': 'shell@adbhost:/ $'
+            'adb -s f57e6b77 shell': 'shell@adbhost:/ $',                    # adb shell is changing prompt so it triggers following 2 send-responses
+            '': 'shell@adbhost:/ $',                                         # to allow for self.connection.sendline("")              in _send_prompt_set()
+            'export PS1="adb_shell@f57e6b77 \\$ "': 'adb_shell@f57e6b77 $'   # to allow for self.connection.sendline(self.set_prompt) in _send_prompt_set()
         },
         "ADB_SHELL": {
             'exit': 'remote#',
-            'su': 'shell@adbhost:/ #',
+            'su': 'adb_shell@f57e6b77 #',
         },
         "ADB_SHELL_ROOT": {
-            'exit': 'shell@adbhost:/ $',
+            'exit': 'adb_shell@f57e6b77 $',
         },
         "UNIX_REMOTE_ROOT": {
             'exit': 'remote#',

--- a/test/resources/device_config.yml
+++ b/test/resources/device_config.yml
@@ -180,9 +180,3 @@ DEVICES:
           execute_command: adb_shell # default value; default command is:  adb shell
           command_params:
             serial_number: 'f57e6b77'  #  to create:  adb -s f57e6b77 shell
-            expected_prompt: 'shell@adbhost:/ \$'
-      ADB_SHELL:
-        ADB_SHELL_ROOT:
-          execute_command: su
-          command_params:
-            expected_prompt: 'shell@adbhost:/ \#'


### PR DESCRIPTION
Allow to work with expected_prompt generated (via PS1) from serial number

You can get serial number from output of
adb devices