### PR TITLE
fix detection of final prompt for Ctrl-C broken commands

### DIFF
--- a/moler/cmd/commandtextualgeneric.py
+++ b/moler/cmd/commandtextualgeneric.py
@@ -285,6 +285,12 @@ class CommandTextualGeneric(Command):
         """
         if self._regex_helper.search_compiled(self._re_prompt, line):
             return True
+        # when command is broken via Ctrl-C then ^C may be appended to start of prompt
+        # if prompt regexp requires "at start of line" via r'^' then such ^C concatenation will falsify prompt
+        if (len(line) > 2) and line.startswith("^C"):
+            non_ctrl_c_started_line = line[2:]
+            if self._regex_helper.search_compiled(self._re_prompt, non_ctrl_c_started_line):
+                return True
         return False
 
     def _strip_new_lines_chars(self, line):

--- a/moler/cmd/commandtextualgeneric.py
+++ b/moler/cmd/commandtextualgeneric.py
@@ -69,6 +69,8 @@ class CommandTextualGeneric(Command):
         self._ignore_unicode_errors = True  # If True then UnicodeDecodeError will be logged not raised in data_received
         self._last_recv_time_data_read_from_connection = None  # Time moment when data was really received from
         # connection (not when was passed to command).  Time is given as datetime.datetime instance
+        self._remove_ctrlc_chars_for_prompt = True  # after sending Ctrl-C response might be concatenated ^Cprompt
+        # This flag removes "^C" from prompt before processing prompt against self._re_prompt
 
         if not self._newline_chars:
             self._newline_chars = CommandTextualGeneric._default_newline_chars
@@ -287,7 +289,7 @@ class CommandTextualGeneric(Command):
             return True
         # when command is broken via Ctrl-C then ^C may be appended to start of prompt
         # if prompt regexp requires "at start of line" via r'^' then such ^C concatenation will falsify prompt
-        if (len(line) > 2) and line.startswith("^C"):
+        if self._remove_ctrlc_chars_for_prompt and (len(line) > 2) and line.startswith("^C"):
             non_ctrl_c_started_line = line[2:]
             if self._regex_helper.search_compiled(self._re_prompt, non_ctrl_c_started_line):
                 return True

--- a/test/cmd/test_commandtextualgeneric.py
+++ b/test/cmd/test_commandtextualgeneric.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Testing CommandTextualGeneric.
+"""
+
+__author__ = 'Grzegorz Latuszek'
+__copyright__ = 'Copyright (C) 2020, Nokia'
+__email__ = 'grzegorz.latuszek@nokia.com'
+
+import pytest
+
+
+def test_correct_closing_of_ctrl_c_broken_command(buffer_connection, textual_command_class):
+
+    cmd = textual_command_class(connection=buffer_connection.moler_connection,
+                                prompt=r"^adb_shell@12345678 \$")
+    assert cmd.is_end_of_cmd_output(line="adb_shell@12345678 $")
+    assert cmd.is_end_of_cmd_output(line="^Cadb_shell@12345678 $")
+    assert not cmd.is_end_of_cmd_output(line="Xadb_shell@12345678 $")
+
+
+@pytest.fixture()
+def textual_command_class():
+    from moler.cmd.commandtextualgeneric import CommandTextualGeneric
+
+    class TextualCommand(CommandTextualGeneric):
+        def build_command_string(self):
+            return "textual_cmd"
+
+    return TextualCommand


### PR DESCRIPTION
logs:


22 17:37:46.576 <|[SUM]  0.0-12.0 sec  1589 KBytes  1084 Kbits/sec   0.177 ms    0/ 1107 (0%)

22 17:37:46.588  |is_end_of_cmd_output([SUM]  0.0-12.0 sec  1589 KBytes  1084 Kbits/sec   0.177 ms    0/ 1107 (0%)) == False
22 17:37:46.615 >|                    >>> here we do break_cmd() sending Ctrl-C <<<
22 17:37:46.625 <|^C
22 17:37:46.628  |is_end_of_cmd_output(^C) == False
22 17:37:47.596 <|adb_shell@e792bf97 $ 
22 17:37:47.597  |is_end_of_cmd_output(^Cadb_shell@e792bf97 $ ) == False  
22 17:37:48.592  |moler.cmd.unix.iperf2.Iperf2("iperf -s -u -p 50010 -f k -P 1 -i 1", id:7f5e9c400a58, awaited_prompt='^adb_shell@e792bf97 \$') has set exception CommandTimeout('Iperf2("iperf -s -u -p 50010 -f k -P 1 -i 1", id:7f5e9c400a58, awaited_prompt=\'^adb_shell@e792bf97 \\$\') background_run time 14.16 >= 14.15 sec timeout',)

________________________________________

22 17:37:48.595  |Timeout when command_string='iperf -s -u -p 50010 -f k -P 1 -i 1', 
                   _last_not_full_line='^Cadb_shell@e792bf97 $ ', 
                   _re_prompt='^adb_shell@e792bf97 \$', 
 
failure because "^C"  is added with "adb_shell@e792bf97 $"
(standard continuation behaviour for incomplete line; but impacts prompt detection)