### PR TITLE
Troubleshoot threads2

### DIFF
--- a/moler/cmd/commandtextualgeneric.py
+++ b/moler/cmd/commandtextualgeneric.py
@@ -225,7 +225,7 @@ class CommandTextualGeneric(Command):
         try:
             lines = data.splitlines(True)
             for current_chunk in lines:
-                if self.__class__.__name__ == 'CmConnect':
+                if self.__class__.__name__ == 'CmConnect':  # pragma: no cover
                     self.logger.debug("{} current_chunk = '{}'".format(self, current_chunk))
                 line, is_full_line = self._update_from_cached_incomplete_line(current_chunk=current_chunk)
                 if self._cmd_output_started:
@@ -234,7 +234,7 @@ class CommandTextualGeneric(Command):
                     self._detect_start_of_cmd_output(self._decode_line(line=line), is_full_line)
                     self._cache_line_before_command_start(line=line, is_full_line=is_full_line)
                 if self.done() and self.do_not_process_after_done:
-                    if self.__class__.__name__ == 'CmConnect':
+                    if self.__class__.__name__ == 'CmConnect':  # pragma: no cover
                         self.logger.debug("{} is done".format(self))
                     break
         except UnicodeDecodeError as ex:
@@ -246,12 +246,12 @@ class CommandTextualGeneric(Command):
                 self._log(lvl=logging.WARNING,
                           msg="Processing data from '{}' raised: '{}'.".format(self, ex))
                 raise ex
-        except Exception as ex:  # log it just to catch that rare hanging thread issue
+        except Exception as ex:  # pragma: no cover # log it just to catch that rare hanging thread issue
             self._log(lvl=logging.WARNING,
                       msg="Processing data from '{}' raised: '{}'.".format(self, ex))
             raise ex
         finally:
-            if self.__class__.__name__ == 'CmConnect':
+            if self.__class__.__name__ == 'CmConnect':  # pragma: no cover
                 self.logger.debug("{} exiting data processing of '{}'".format(self, data))
 
     def _process_line_from_command(self, current_chunk, line, is_full_line):
@@ -264,7 +264,7 @@ class CommandTextualGeneric(Command):
         :return: None.
         """
         decoded_line = self._decode_line(line=line)
-        if self.__class__.__name__ == 'CmConnect':
+        if self.__class__.__name__ == 'CmConnect':  # pragma: no cover
             self.logger.debug("{} line = '{}', decoded_line = '{}', is_full_line={}".format(self, line, decoded_line, is_full_line))
         self.on_new_line(line=decoded_line, is_full_line=is_full_line)
 
@@ -373,7 +373,7 @@ class CommandTextualGeneric(Command):
         if (is_full_line and self.newline_after_command_string) or not self.newline_after_command_string:
             if self._regex_helper.search_compiled(self._cmd_escaped, line):
                 self._cmd_output_started = True
-        if self.__class__.__name__ == 'CmConnect':
+        if self.__class__.__name__ == 'CmConnect':  # pragma: no cover
             self.logger.debug("{} line = '{}', is_full_line={}, _cmd_output_started={}".format(self, line, is_full_line, self._cmd_output_started))
 
     def break_cmd(self, silent=False):

--- a/moler/cmd/commandtextualgeneric.py
+++ b/moler/cmd/commandtextualgeneric.py
@@ -225,6 +225,8 @@ class CommandTextualGeneric(Command):
         try:
             lines = data.splitlines(True)
             for current_chunk in lines:
+                if self.__class__.__name__ == 'CmConnect':
+                    self.logger.debug("{} current_chunk = '{}'".format(self, current_chunk))
                 line, is_full_line = self._update_from_cached_incomplete_line(current_chunk=current_chunk)
                 if self._cmd_output_started:
                     self._process_line_from_command(line=line, current_chunk=current_chunk, is_full_line=is_full_line)
@@ -232,13 +234,25 @@ class CommandTextualGeneric(Command):
                     self._detect_start_of_cmd_output(self._decode_line(line=line), is_full_line)
                     self._cache_line_before_command_start(line=line, is_full_line=is_full_line)
                 if self.done() and self.do_not_process_after_done:
+                    if self.__class__.__name__ == 'CmConnect':
+                        self.logger.debug("{} is done".format(self))
                     break
         except UnicodeDecodeError as ex:
             if self._ignore_unicode_errors:
                 self._log(lvl=logging.WARNING,
                           msg="Processing data from '{}' with unicode problem: '{}'.".format(self, ex))
             else:
+                # log it just to catch that rare hanging thread issue
+                self._log(lvl=logging.WARNING,
+                          msg="Processing data from '{}' raised: '{}'.".format(self, ex))
                 raise ex
+        except Exception as ex:  # log it just to catch that rare hanging thread issue
+            self._log(lvl=logging.WARNING,
+                      msg="Processing data from '{}' raised: '{}'.".format(self, ex))
+            raise ex
+        finally:
+            if self.__class__.__name__ == 'CmConnect':
+                self.logger.debug("{} exiting data processing of '{}'".format(self, data))
 
     def _process_line_from_command(self, current_chunk, line, is_full_line):
         """
@@ -250,6 +264,8 @@ class CommandTextualGeneric(Command):
         :return: None.
         """
         decoded_line = self._decode_line(line=line)
+        if self.__class__.__name__ == 'CmConnect':
+            self.logger.debug("{} line = '{}', decoded_line = '{}', is_full_line={}".format(self, line, decoded_line, is_full_line))
         self.on_new_line(line=decoded_line, is_full_line=is_full_line)
 
     def _cache_line_before_command_start(self, line, is_full_line):
@@ -357,6 +373,8 @@ class CommandTextualGeneric(Command):
         if (is_full_line and self.newline_after_command_string) or not self.newline_after_command_string:
             if self._regex_helper.search_compiled(self._cmd_escaped, line):
                 self._cmd_output_started = True
+        if self.__class__.__name__ == 'CmConnect':
+            self.logger.debug("{} line = '{}', is_full_line={}, _cmd_output_started={}".format(self, line, is_full_line, self._cmd_output_started))
 
     def break_cmd(self, silent=False):
         """

--- a/moler/runner.py
+++ b/moler/runner.py
@@ -424,6 +424,7 @@ class ThreadPoolExecutorRunner(ConnectionObserverRunner):
                 time_out_observer(connection_observer=connection_observer,
                                   timeout=timeout, passed_time=passed,
                                   runner_logger=self.logger, kind="await_done")
+            self.logger.debug(">>> Exited   {}. conn-obs '{}' runner '{}' future '{}'".format(future.observer_lock, connection_observer, self, future))
         else:
             # sorry, we don't have lock yet (it is created by runner.submit()
             time_out_observer(connection_observer=connection_observer,
@@ -461,6 +462,7 @@ class ThreadPoolExecutorRunner(ConnectionObserverRunner):
                     self.logger.debug(u">>> Entered  {}. conn-obs '{}' runner '{}' data '{}'".format(observer_lock, connection_observer, self, data))
                     connection_observer.data_received(data, timestamp)
                     connection_observer.life_status.last_feed_time = time.time()
+                self.logger.debug(u">>> Exited   {}. conn-obs '{}' runner '{}' data '{}'".format(observer_lock, connection_observer, self, data))
 
             except Exception as exc:  # TODO: handling stacktrace
                 # observers should not raise exceptions during data parsing
@@ -477,6 +479,7 @@ class ThreadPoolExecutorRunner(ConnectionObserverRunner):
                     else:
                         ex = MolerException(ex_msg)
                     connection_observer.set_exception(ex)
+                self.logger.debug(">>> Exited   err {}. conn-obs '{}' runner. '{}'".format(observer_lock, connection_observer, self))
             finally:
                 if connection_observer.done() and not connection_observer.cancelled():
                     if connection_observer._exception:
@@ -495,6 +498,7 @@ class ThreadPoolExecutorRunner(ConnectionObserverRunner):
             remain_time, msg = his_remaining_time("remaining", timeout=connection_observer.timeout,
                                                   from_start_time=connection_observer.life_status.start_time)
             connection_observer._log(logging.INFO, "{} started, {}".format(connection_observer.get_long_desc(), msg))
+        self.logger.debug(">>> Exited   {}. conn-obs '{}' runner '{}' moler-conn '{}'".format(observer_lock, connection_observer, self, moler_conn))
         if connection_observer.is_command():
             connection_observer.send_command()
         return secure_data_received  # to know what to unsubscribe
@@ -514,6 +518,7 @@ class ThreadPoolExecutorRunner(ConnectionObserverRunner):
                 connection_observer._log(logging.INFO,
                                          "{} finished, {}".format(connection_observer.get_short_desc(), msg))
                 feed_done.set()
+        self.logger.debug(">>> Exited   {}. conn-obs '{}' runner '{}'".format(observer_lock, connection_observer, self))
 
     def _feed_finish_callback(self, future, connection_observer, subscribed_data_receiver, feed_done, observer_lock):
         """Callback attached to concurrent.futures.Future of submitted feed()"""
@@ -585,6 +590,7 @@ class ThreadPoolExecutorRunner(ConnectionObserverRunner):
                             connection_observer.life_status.in_terminating = True
                         else:
                             break
+                    self.logger.debug(">>> Exited   {}. conn-obs '{}' runner '{}'".format(observer_lock, connection_observer, self))
             else:
                 self._call_on_inactivity(connection_observer=connection_observer, current_time=current_time)
 

--- a/moler/threaded_moler_connection.py
+++ b/moler/threaded_moler_connection.py
@@ -93,6 +93,7 @@ class ThreadedMolerConnection(AbstractMolerConnection):
                 self._observer_wrappers[observer_key] = ObserverThreadWrapper(
                     observer=observer_reference, observer_self=self_for_observer, logger=self.logger)
                 self._connection_closed_handlers[observer_key] = connection_closed_handler
+        self.logger.debug(">>> Exited   {}. conn-obs '{}' moler-conn '{}'".format(self._observers_lock, observer, self))
 
     def unsubscribe(self, observer, connection_closed_handler):
         """
@@ -113,6 +114,7 @@ class ThreadedMolerConnection(AbstractMolerConnection):
                 self._log(level=logging.WARNING,
                           msg="{} and {} were not both subscribed.".format(observer, connection_closed_handler),
                           levels_to_go_up=2)
+        self.logger.debug(">>> Exited   {}. conn-obs '{}' moler-conn '{}'".format(self._observers_lock, observer, self))
 
     def shutdown(self):
         """

--- a/moler/util/tracked_thread.py
+++ b/moler/util/tracked_thread.py
@@ -49,10 +49,9 @@ def report_alive(report_tick=5.0):
 
 
 def threads_dumper(report_tick=10.0):
-    logger = logging.getLogger("moler_threads")
     while True:
         time.sleep(report_tick)
-        logger.info("ACTIVE: {}".format(threading.enumerate()))
+        logging.getLogger("moler_threads").info("ACTIVE: {}".format(threading.enumerate()))
 
 
 def start_threads_dumper():

--- a/moler/util/tracked_thread.py
+++ b/moler/util/tracked_thread.py
@@ -10,7 +10,8 @@ import time
 # shutdown and thus raises an exception about trying to perform some
 # operation on/with a NoneType
 _exc_info = sys.exc_info
-do_threads_debug = os.getenv('MOLER_DEBUG_THREADS', 'False').lower() in ('true', 't', 'yes', 'y', '1')
+# do_threads_debug = os.getenv('MOLER_DEBUG_THREADS', 'False').lower() in ('true', 't', 'yes', 'y', '1')
+do_threads_debug = os.getenv('MOLER_DEBUG_THREADS', 'True').lower() in ('true', 't', 'yes', 'y', '1')  # just to catch that rare hanging thread issue
 
 
 def log_exit_exception(fun):
@@ -33,27 +34,21 @@ def log_exit_exception(fun):
     return thread_exceptions_catcher
 
 
-def report_alive(report_tick=1.0):  # TODO: 10sec for production
-    # logger = logging.getLogger("moler_threads")
-    # logger.debug("I'm alive")
+def report_alive(report_tick=5.0):
     last_report_time = time.time()
-    # cnt = 2
     do_report = True
     while True:
         yield do_report  # TODO log long loop tick, allowed_loop_tick as param
         now = time.time()
         delay = now - last_report_time
         if delay >= report_tick:
-            # logger.debug("I'm alive")
             last_report_time = now
             do_report = do_threads_debug
         else:
             do_report = False
-        # cnt -= 1
-        # a = 3 / cnt  # for testing exception inside thread causing thread to exit
 
 
-def threads_dumper(report_tick=1.0):  # TODO: 10sec for production
+def threads_dumper(report_tick=10.0):
     logger = logging.getLogger("moler_threads")
     while True:
         time.sleep(report_tick)


### PR DESCRIPTION
Troubleshooting code to catch rare case when whole moler hangs. It happens during testing CmConnect command.
Seems like something blocked exiting from data_received() or exiting from thread locks.
There was an issue inside Python itself, issue related to thread locks:
https://bugs.python.org/issue38106 - however, it was macOS specific.
Maybe here, we have something similar?

Need detailed logs to prove that assumption before any trial to fix it.