### PR TITLE
fix error when handling values in bytes unit - converterhelper

### DIFF
--- a/moler/cmd/unix/iperf3.py
+++ b/moler/cmd/unix/iperf3.py
@@ -360,7 +360,7 @@ class Iperf3(Iperf2):
             elif not isinstance(raw_value, int) and ("bits" in raw_value):
                 new_dict[key + " Raw"] = raw_value
                 value, unit = raw_value.split(" ")
-                unit_bits = unit.split("/")
+                unit_bits, _ = unit.split("/")
                 if unit_bits == "bits":
                     value_in_bits = float(value)
                 else:
@@ -376,7 +376,7 @@ class Iperf3(Iperf2):
         # jitter value in milliseconds
         for key in list(input_dict):
             raw_value = input_dict[key]
-            if not isinstance(raw_value, int) and "ms" in raw_value:
+            if not isinstance(raw_value, (int, float)) and "ms" in raw_value:
                 input_dict[key + " Raw"] = raw_value
                 value_in_ms, _ = raw_value.split(" ")
                 value_in_ms = float(value_in_ms)
@@ -521,6 +521,147 @@ COMMAND_RESULT_basic_client = {
                                                                10.05),
                                                   'Transfer': 31245887078,
                                                   'Transfer Raw': '29.1 GBytes'}]},
+    'INFO': ['Connecting to host 127.0.0.1, port 5201',
+             'iperf Done.']}
+
+
+COMMAND_OUTPUT_basic_client_bytes_bits_convert = """
+xyz@debian:~$ iperf3 -c 127.0.0.1 -i 1
+Connecting to host 127.0.0.1, port 5201
+[  5] local 127.0.0.1 port 48058 connected to 127.0.0.1 port 5201
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec  3.16 GBytes  27.2 Gbits/sec    0   1.25 MBytes
+[  5]   1.00-2.00   sec  4.17 GBytes  35.8 Gbits/sec    0   1.25 MBytes
+[  5]   2.00-3.00   sec  2.40 GBytes  20.6 Gbits/sec    0   1.25 MBytes
+[  5]   3.00-4.00   sec  2.40 GBytes  20.6 Gbits/sec    0   3.18 MBytes
+[  5]   4.00-5.00   sec  2.36 GBytes  20.2 Gbits/sec    0   3.18 MBytes
+[  5]   5.00-6.00   sec  2.40 GBytes  20.6 Gbits/sec    0   3.18 MBytes
+[  5]   6.00-7.00   sec  2.41 GBytes  20.7 Gbits/sec    0   3.18 MBytes
+[  5]   7.00-8.00   sec  2.37 GBytes  20.4 Gbits/sec    0   4.81 MBytes
+[  5]   8.00-9.00   sec  3.89 GBytes  33.4 Gbits/sec    0   4.81 MBytes
+[  5]   9.00-10.00  sec  3.56 GBytes  30.6 Gbits/sec    0   4.81 MBytes
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-10.00  sec  29.1 GBytes  25.0 Gbits/sec    0             sender
+[  5]   0.00-10.05  sec  0.00 Bytes   0.00 bits/sec                   receiver
+
+iperf Done.
+xyz@debian:~$"""
+
+COMMAND_KWARGS_basic_client_bytes_bits_convert = {"options": "-c 127.0.0.1 -i 1"}
+
+COMMAND_RESULT_basic_client_bytes_bits_convert = {
+    'CONNECTIONS':
+        {('127.0.0.1', '5201@127.0.0.1'): {'report': {'Bitrate': 3125000000,
+                                                      'Bitrate Raw': '25.0 Gbits/sec',
+                                                      'Interval': (0.0,
+                                                                     10.0),
+                                                      'Retr': 0,
+                                                      'Transfer': 31245887078,
+                                                      'Transfer Raw': '29.1 GBytes'}},
+         ('48058@127.0.0.1', '5201@127.0.0.1'): [{'Bitrate': 3400000000,
+                                                  'Bitrate Raw': '27.2 Gbits/sec',
+                                                  'Cwnd': 1310720,
+                                                  'Cwnd Raw': '1.25 MBytes',
+                                                  'Interval': (0.0,
+                                                               1.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 3393024163,
+                                                  'Transfer Raw': '3.16 GBytes'},
+                                                 {'Bitrate': 4475000000,
+                                                  'Bitrate Raw': '35.8 Gbits/sec',
+                                                  'Cwnd': 1310720,
+                                                  'Cwnd Raw': '1.25 MBytes',
+                                                  'Interval': (1.0,
+                                                               2.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 4477503406,
+                                                  'Transfer Raw': '4.17 GBytes'},
+                                                 {'Bitrate': 2575000000,
+                                                  'Bitrate Raw': '20.6 Gbits/sec',
+                                                  'Cwnd': 1310720,
+                                                  'Cwnd Raw': '1.25 MBytes',
+                                                  'Interval': (2.0,
+                                                               3.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 2576980377,
+                                                  'Transfer Raw': '2.40 GBytes'},
+                                                 {'Bitrate': 2575000000,
+                                                  'Bitrate Raw': '20.6 Gbits/sec',
+                                                  'Cwnd': 3334471,
+                                                  'Cwnd Raw': '3.18 MBytes',
+                                                  'Interval': (3.0,
+                                                               4.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 2576980377,
+                                                  'Transfer Raw': '2.40 GBytes'},
+                                                 {'Bitrate': 2525000000,
+                                                  'Bitrate Raw': '20.2 Gbits/sec',
+                                                  'Cwnd': 3334471,
+                                                  'Cwnd Raw': '3.18 MBytes',
+                                                  'Interval': (4.0,
+                                                               5.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 2534030704,
+                                                  'Transfer Raw': '2.36 GBytes'},
+                                                 {'Bitrate': 2575000000,
+                                                  'Bitrate Raw': '20.6 Gbits/sec',
+                                                  'Cwnd': 3334471,
+                                                  'Cwnd Raw': '3.18 MBytes',
+                                                  'Interval': (5.0,
+                                                               6.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 2576980377,
+                                                  'Transfer Raw': '2.40 GBytes'},
+                                                 {'Bitrate': 2587500000,
+                                                  'Bitrate Raw': '20.7 Gbits/sec',
+                                                  'Cwnd': 3334471,
+                                                  'Cwnd Raw': '3.18 MBytes',
+                                                  'Interval': (6.0,
+                                                               7.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 2587717795,
+                                                  'Transfer Raw': '2.41 GBytes'},
+                                                 {'Bitrate': 2550000000,
+                                                  'Bitrate Raw': '20.4 Gbits/sec',
+                                                  'Cwnd': 5043650,
+                                                  'Cwnd Raw': '4.81 MBytes',
+                                                  'Interval': (7.0,
+                                                               8.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 2544768122,
+                                                  'Transfer Raw': '2.37 GBytes'},
+                                                 {'Bitrate': 4175000000,
+                                                  'Bitrate Raw': '33.4 Gbits/sec',
+                                                  'Cwnd': 5043650,
+                                                  'Cwnd Raw': '4.81 MBytes',
+                                                  'Interval': (8.0,
+                                                               9.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 4176855695,
+                                                  'Transfer Raw': '3.89 GBytes'},
+                                                 {'Bitrate': 3825000000,
+                                                  'Bitrate Raw': '30.6 Gbits/sec',
+                                                  'Cwnd': 5043650,
+                                                  'Cwnd Raw': '4.81 MBytes',
+                                                  'Interval': (9.0,
+                                                               10.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 3822520893,
+                                                  'Transfer Raw': '3.56 GBytes'},
+                                                 {'Bitrate': 3125000000,
+                                                  'Bitrate Raw': '25.0 Gbits/sec',
+                                                  'Interval': (0.0,
+                                                               10.0),
+                                                  'Retr': 0,
+                                                  'Transfer': 31245887078,
+                                                  'Transfer Raw': '29.1 GBytes'},
+                                                 {'Bitrate': 0,
+                                                  'Bitrate Raw': '0.00 bits/sec',
+                                                  'Interval': (0.0,
+                                                               10.05),
+                                                  'Transfer': 0,
+                                                  'Transfer Raw': '0.00 Bytes'}]},
     'INFO': ['Connecting to host 127.0.0.1, port 5201',
              'iperf Done.']}
 

--- a/moler/cmd/unix/iperf3.py
+++ b/moler/cmd/unix/iperf3.py
@@ -328,7 +328,8 @@ class Iperf3(Iperf2):
             return False
         result = self.current_ret["CONNECTIONS"]
         connections = list(self._connection_dict.values())
-        client_host, _, server_host, _ = self._split_connection_name(connections[0])
+        client_host, _, server_host, _ = self._split_connection_name(
+            connections[0])
         return (client_host, "{}@{}".format(
             self.port, server_host)) in result
 
@@ -539,7 +540,8 @@ Connecting to host 127.0.0.1, port 5201
 iperf Done.
 xyz@debian:~$"""
 
-COMMAND_KWARGS_basic_client_bytes_bits_convert = {"options": "-c 127.0.0.1 -i 1"}
+COMMAND_KWARGS_basic_client_bytes_bits_convert = {
+    "options": "-c 127.0.0.1 -i 1"}
 
 COMMAND_RESULT_basic_client_bytes_bits_convert = {
     'CONNECTIONS':
@@ -647,11 +649,11 @@ COMMAND_RESULT_basic_client_bytes_bits_convert = {
                                                   'Retr': 0,
                                                   'Transfer': 31245887078,
                                                   'Transfer Raw': '29.1 GBytes'},
-                                                 {'Bitrate': 0.0,
+                                                 {'Bitrate': 0,
                                                   'Bitrate Raw': '0.00 bits/sec',
                                                   'Interval': (0.0,
                                                                10.05),
-                                                  'Transfer': 0.0,
+                                                  'Transfer': 0,
                                                   'Transfer Raw': '0.00 Bytes'}]},
     'INFO': ['Connecting to host 127.0.0.1, port 5201',
              'iperf Done.']}

--- a/moler/cmd/unix/iperf3.py
+++ b/moler/cmd/unix/iperf3.py
@@ -349,14 +349,23 @@ class Iperf3(Iperf2):
             # iperf MBytes means 1024 * 1024 Bytes - see iperf.fr/iperf-doc.php
             if not isinstance(raw_value, int) and ("Bytes" in raw_value):
                 new_dict[key + " Raw"] = raw_value
-                value_in_bytes, _, _ = self._converter_helper.to_bytes(
-                    raw_value)
+                value, unit = raw_value.split(" ")
+                if unit == "Bytes":
+                    value_in_bytes = float(value)
+                else:
+                    value_in_bytes, _, _ = self._converter_helper.to_bytes(
+                        raw_value)
                 new_dict[key] = value_in_bytes
             # iperf Mbits means 1000 * 1000 bits - see iperf.fr/iperf-doc.php
             elif not isinstance(raw_value, int) and ("bits" in raw_value):
                 new_dict[key + " Raw"] = raw_value
-                value_in_bits, _, _ = self._converter_helper.to_bytes(
-                    raw_value, binary_multipliers=False)
+                value, unit = raw_value.split(" ")
+                unit_bits = unit.split("/")
+                if unit_bits == "bits":
+                    value_in_bits = float(value)
+                else:
+                    value_in_bits, _, _ = self._converter_helper.to_bytes(
+                        raw_value, binary_multipliers=False)
                 value_in_bytes = value_in_bits // 8
                 new_dict[key] = value_in_bytes
             else:

--- a/moler/cmd/unix/iperf3.py
+++ b/moler/cmd/unix/iperf3.py
@@ -349,23 +349,14 @@ class Iperf3(Iperf2):
             # iperf MBytes means 1024 * 1024 Bytes - see iperf.fr/iperf-doc.php
             if not isinstance(raw_value, int) and ("Bytes" in raw_value):
                 new_dict[key + " Raw"] = raw_value
-                value, unit = raw_value.split(" ")
-                if unit == "Bytes":
-                    value_in_bytes = float(value)
-                else:
-                    value_in_bytes, _, _ = self._converter_helper.to_bytes(
-                        raw_value)
+                value_in_bytes, _, _ = self._converter_helper.to_bytes(
+                    raw_value)
                 new_dict[key] = value_in_bytes
             # iperf Mbits means 1000 * 1000 bits - see iperf.fr/iperf-doc.php
             elif not isinstance(raw_value, int) and ("bits" in raw_value):
                 new_dict[key + " Raw"] = raw_value
-                value, unit = raw_value.split(" ")
-                unit_bits, _ = unit.split("/")
-                if unit_bits == "bits":
-                    value_in_bits = float(value)
-                else:
-                    value_in_bits, _, _ = self._converter_helper.to_bytes(
-                        raw_value, binary_multipliers=False)
+                value_in_bits, _, _ = self._converter_helper.to_bytes(
+                    raw_value, binary_multipliers=False)
                 value_in_bytes = value_in_bits // 8
                 new_dict[key] = value_in_bytes
             else:

--- a/moler/cmd/unix/iperf3.py
+++ b/moler/cmd/unix/iperf3.py
@@ -656,11 +656,11 @@ COMMAND_RESULT_basic_client_bytes_bits_convert = {
                                                   'Retr': 0,
                                                   'Transfer': 31245887078,
                                                   'Transfer Raw': '29.1 GBytes'},
-                                                 {'Bitrate': 0,
+                                                 {'Bitrate': 0.0,
                                                   'Bitrate Raw': '0.00 bits/sec',
                                                   'Interval': (0.0,
                                                                10.05),
-                                                  'Transfer': 0,
+                                                  'Transfer': 0.0,
                                                   'Transfer Raw': '0.00 Bytes'}]},
     'INFO': ['Connecting to host 127.0.0.1, port 5201',
              'iperf Done.']}

--- a/moler/util/converterhelper.py
+++ b/moler/util/converterhelper.py
@@ -13,8 +13,9 @@ import re
 class ConverterHelper(object):
     _instance = None
     # examples of matched strings: 1K 1 .5M  3.2G
-    _re_to_bytes = re.compile(
-        r"(?P<VALUE>\d+\.?\d*|\.\d+)\s*(?P<FULL_UNIT>(?P<UNIT>\w?)\w*)")
+    _re_to_bytes = re.compile(r"(?P<VALUE>\d+\.?\d*|\.\d+)\s*(?P<UNIT>\w?)")
+
+    # 'b' stands for no decimal and binary prefix
     _binary_multipliers = {
         "b": 1,
         "k": 1024,

--- a/moler/util/converterhelper.py
+++ b/moler/util/converterhelper.py
@@ -13,8 +13,10 @@ import re
 class ConverterHelper(object):
     _instance = None
     # examples of matched strings: 1K 1 .5M  3.2G
-    _re_to_bytes = re.compile(r"(?P<VALUE>\d+\.?\d*|\.\d+)\s*(?P<UNIT>\w?)")
+    _re_to_bytes = re.compile(
+        r"(?P<VALUE>\d+\.?\d*|\.\d+)\s*(?P<FULL_UNIT>(?P<UNIT>\w?)\w*)")
     _binary_multipliers = {
+        "b": 1,
         "k": 1024,
         "m": 1024 * 1024,
         "g": 1024 * 1024 * 1024,
@@ -25,6 +27,7 @@ class ConverterHelper(object):
         "j": 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
     }
     _dec_multipliers = {
+        "b": 1,
         "k": 1000,
         "m": 1000 * 1000,
         "g": 1000 * 1000 * 1000,
@@ -64,7 +67,8 @@ class ConverterHelper(object):
             if value_unit in multipliers:
                 value_in_bytes = int(multipliers[value_unit] * value_in_units)
             else:
-                raise ValueError("Unsupported unit '{}' in passed value: '{}'".format(value_unit, str_bytes))
+                raise ValueError(
+                    "Unsupported unit '{}' in passed value: '{}'".format(value_unit, str_bytes))
         return value_in_bytes, value_in_units, value_unit
 
     def to_seconds_str(self, str_time):
@@ -90,7 +94,8 @@ class ConverterHelper(object):
         :return: number of seconds
         """
         if unit not in ConverterHelper._seconds_multipliers:
-            raise ValueError("Unsupported unit '{}' for passed value: '{}'".format(unit, value))
+            raise ValueError(
+                "Unsupported unit '{}' for passed value: '{}'".format(unit, value))
         return ConverterHelper._seconds_multipliers[unit] * value
 
     def to_number(self, value, raise_exception=True):

--- a/test/cmd/unix/test_cmd_iperf3.py
+++ b/test/cmd/unix/test_cmd_iperf3.py
@@ -156,6 +156,16 @@ def test_iperf_correctly_parses_basic_tcp_client_output(buffer_connection):
     assert res == iperf3.COMMAND_RESULT_basic_client
 
 
+def test_iperf_correctly_parses_basic_tcp_client_bytes_bits_convert_output(buffer_connection):
+    from moler.cmd.unix import iperf3
+    buffer_connection.remote_inject_response(
+        [iperf3.COMMAND_OUTPUT_basic_client_bytes_bits_convert])
+    iperf_cmd = iperf3.Iperf3(connection=buffer_connection.moler_connection,
+                              **iperf3.COMMAND_KWARGS_basic_client_bytes_bits_convert)
+    res = iperf_cmd()
+    assert res == iperf3.COMMAND_RESULT_basic_client_bytes_bits_convert
+
+
 def test_iperf_correctly_parses_tcp_ipv6_client_output(buffer_connection):
     from moler.cmd.unix import iperf3
     buffer_connection.remote_inject_response(

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -89,6 +89,15 @@ def test_converterhelper_seconds_wrong_unit():
         converter.to_seconds_str("3UU")
 
 
+def test_converterhelper_bytes():
+    from moler.util.converterhelper import ConverterHelper
+    converter = ConverterHelper.get_converter_helper()
+    bytes_value, value_in_units, unit = converter.to_bytes("0.00 Bytes")
+    assert 0.0 == bytes_value
+    assert 0.0 == value_in_units
+    assert 'b' == unit
+
+
 def test_copy_list():
     from moler.helpers import copy_list
     src = [1]


### PR DESCRIPTION
The iperf3 module does not recognize bytes unit in some statistics.
Made changes in the converterhelper.py module.