### PR TITLE
Add ctrl z `wait` command and add escape code `[2004h` `[2004l` filter in helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## moler 3.5.0
+* Unix commands - optional ctrl + z and kill on timeout - add `wait` call after `kill`
+* Add helper for excape codes `[2004l` `[2004h`
+
 ## moler 3.4.0
 * StateMachine - lock to avoid race conditions
 * Command failure regular expression and exceptions for them

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2024, Nokia'
 author = 'Nokia'
 
 # The short X.Y version
-version = '3.4.0'
+version = '3.5.0'
 # The full version, including alpha/beta/rc tags
 release = 'stable'
 

--- a/moler/cmd/unix/genericunix.py
+++ b/moler/cmd/unix/genericunix.py
@@ -156,8 +156,7 @@ class GenericUnixCommand(CommandTextualGeneric):
             raise ParsingDone()
 
         if self._kill_ctrl_z_sent and (
-            self._regex_helper.search_compiled(GenericUnixCommand._re_kill_done, line)
-            or self._regex_helper.search_compiled(GenericUnixCommand._re_kill_no_job, line)
+            self._regex_helper.search_compiled(GenericUnixCommand._re_kill_done, line) or self._regex_helper.search_compiled(GenericUnixCommand._re_kill_no_job, line)
         ):
             self._kill_ctrl_z_job_done = True
             raise ParsingDone()

--- a/moler/cmd/unix/genericunix.py
+++ b/moler/cmd/unix/genericunix.py
@@ -48,6 +48,7 @@ class GenericUnixCommand(CommandTextualGeneric):
 
         self._ctrl_z_sent = False
         self._kill_ctrl_z_sent = False
+        self._kill_ctrl_z_job_done = False
         self._instance_timeout_action = None
 
     def _decode_line(self, line: str) -> str:
@@ -126,12 +127,18 @@ class GenericUnixCommand(CommandTextualGeneric):
         :param line: Line from device.
         :return: True if end of command is reached, False otherwise.
         """
-        if not self._kill_ctrl_z_sent and self._ctrl_z_sent:
+        if not self._kill_ctrl_z_job_done and self._ctrl_z_sent:
             return False
         return super(GenericUnixCommand, self).is_end_of_cmd_output(line=line)
 
     # [2]+  Stopped
     _re_ctrl_z_stopped = re.compile(r"\[(?P<JOB_ID>\d+)\]\+\s+Stopped")
+
+    # [2]+  Done
+    _re_kill_done = re.compile(r"\[(?P<JOB_ID>\d+)\]\+\s+Done")
+
+    # -bash: wait: %2: no such job
+    _re_kill_no_job = re.compile(r":\s\%(?P<JOB_ID>\d+): no such job")
 
     def _parse_control_z(self, line: str) -> None:
         """
@@ -140,8 +147,17 @@ class GenericUnixCommand(CommandTextualGeneric):
         :param line: Line from device.
         :return: None.
         """
-        if self._ctrl_z_sent and not self._kill_ctrl_z_sent and self._regex_helper.search_compiled(GenericUnixCommand._re_ctrl_z_stopped, line):
+        if self._ctrl_z_sent and not self._kill_ctrl_z_job_done and self._regex_helper.search_compiled(
+            GenericUnixCommand._re_ctrl_z_stopped, line
+        ):
             job_id = self._regex_helper.group("JOB_ID")
-            self.connection.sendline(f"kill %{job_id}")
+            self.connection.sendline(f"kill %{job_id}; wait %{job_id}")
             self._kill_ctrl_z_sent = True
+            raise ParsingDone()
+
+        if self._kill_ctrl_z_sent and (
+            self._regex_helper.search_compiled(GenericUnixCommand._re_kill_done, line)
+            or self._regex_helper.search_compiled(GenericUnixCommand._re_kill_no_job, line)
+        ):
+            self._kill_ctrl_z_job_done = True
             raise ParsingDone()

--- a/moler/cmd/unix/genericunix.py
+++ b/moler/cmd/unix/genericunix.py
@@ -3,9 +3,9 @@
 Generic Unix/Linux module
 """
 
-__author__ = 'Marcin Usielski'
+__author__ = 'Marcin Usielski', 'Jakub Kochaniak'
 __copyright__ = 'Copyright (C) 2018-2024, Nokia'
-__email__ = 'marcin.usielski@nokia.com'
+__email__ = 'marcin.usielski@nokia.com', 'jakub.kochaniak@nokia.com'
 
 import re
 import abc
@@ -135,10 +135,10 @@ class GenericUnixCommand(CommandTextualGeneric):
     _re_ctrl_z_stopped = re.compile(r"\[(?P<JOB_ID>\d+)\]\+\s+Stopped")
 
     # [2]+  Done
-    _re_kill_done = re.compile(r"\[(?P<JOB_ID>\d+)\]\+\s+Done")
+    _re_kill_done = re.compile(r"\[?\d+\]\+\s+Done")
 
     # -bash: wait: %2: no such job
-    _re_kill_no_job = re.compile(r":\s\%(?P<JOB_ID>\d+): no such job")
+    _re_kill_no_job = re.compile(r"\:\s+\%\d+\s?\:\s+no such job")
 
     def _parse_control_z(self, line: str) -> None:
         """

--- a/moler/helpers.py
+++ b/moler/helpers.py
@@ -99,7 +99,9 @@ def remove_escape_codes(line):
 # ESC [ ? 12 l   Stop blinking the cursor
 # ESC [ ? 25 h   Show the cursor
 # ESC [ ? 25 l   Show the cursor
-_re_cursor_visibility_codes = re.compile(r"\x1B\[\?(12|25)[hl]")
+# ESC [ ? 2004 l Control sequence odd character
+# ESC [ ? 2004 h Control sequence odd character
+_re_cursor_visibility_codes = re.compile(r"\x1B\[\?(12|25|2004)[hl]")
 
 
 def remove_cursor_visibility_codes(multiline):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with io.open(join(here, 'requirements.txt'), encoding='utf-8') as f:
 
 setup(
     name='moler',
-    version='3.4.0',
+    version='3.5.0',
     description='Moler is a library for working with terminals, mainly for automated tests',  # Required
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/test/cmd/unix/test_cmd_run_script.py
+++ b/test/cmd/unix/test_cmd_run_script.py
@@ -63,9 +63,10 @@ def test_run_script_ctrl_z(buffer_connection):
     output1_nl = f"{output1}\n"
     output2 = "...\n"
     output3 = "[4]+  Stopped                 {output1}\n"
-    output4 = "moler_bash# kill %4\n"
+    output4 = "moler_bash# kill %4; wait %4\n"
     output5 = f"\n{output3}\n"
-    output6 = "moler_bash#"
+    output6 = f"[4]+  Done                 {output1}\n"
+    output7 = "moler_bash#"
     cmd = RunScript(connection=buffer_connection.moler_connection, script_command=output1)
     cmd.set_timeout_action(action='z')
     assert cmd._cmd_output_started is False
@@ -89,6 +90,9 @@ def test_run_script_ctrl_z(buffer_connection):
     buffer_connection.moler_connection.data_received(output5.encode("utf-8"), datetime.datetime.now())
     time.sleep(0.1)
     buffer_connection.moler_connection.data_received(output6.encode("utf-8"), datetime.datetime.now())
+    time.sleep(0.1)
+    buffer_connection.moler_connection.data_received(output7.encode("utf-8"), datetime.datetime.now())
+    assert cmd._kill_ctrl_z_job_done is True
     with pytest.raises(CommandTimeout):
         cmd.await_done()
 


### PR DESCRIPTION
## moler 3.5.0
* Unix commands - optional ctrl + z and kill on timeout - add `wait` call after `kill`
* Add helper for excape codes `[2004l` `[2004h`