### PR TITLE
fix in iperf3.py _parse_headers regex used in the function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## moler 3.7.0
+ * Changed regex in iperf3 cmd _parse_header to accept 'Bitrate' and 'Bandwidth' to support older iperf3 versions
+
 ## moler 3.6.0
  * Optional pause Wait4Prompts during state change
  * Added CRT tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![image](https://img.shields.io/badge/pypi-v3.6.0-blue.svg)](https://pypi.org/project/moler/)
+[![image](https://img.shields.io/badge/pypi-v3.7.0-blue.svg)](https://pypi.org/project/moler/)
 [![image](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/moler/)
 [![Build Status](https://github.com/nokia/moler/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/nokia/moler/actions)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](./LICENSE)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2024, Nokia'
 author = 'Nokia'
 
 # The short X.Y version
-version = '3.6.0'
+version = '3.7.0'
 # The full version, including alpha/beta/rc tags
 release = 'stable'
 

--- a/moler/cmd/unix/iperf3.py
+++ b/moler/cmd/unix/iperf3.py
@@ -236,9 +236,6 @@ class Iperf3(Iperf2):
             iperf_record = self._convert_retr_parameter(iperf_record)
             iperf_record = self._convert_datagrams_parameter(iperf_record)
 
-            if (not self.parallel_client) and (connection_id == "[SUM]"):
-                raise ParsingDone  # skip it
-
             connection_name = self._connection_dict[connection_id]
             normalized_iperf_record = self._normalize_to_bytes(iperf_record)
             normalized_iperf_record = self._convert_jitter(

--- a/moler/cmd/unix/iperf3.py
+++ b/moler/cmd/unix/iperf3.py
@@ -156,7 +156,6 @@ class Iperf3(Iperf2):
     _re_headers = re.compile(r"\[\s+ID\]\s+Interval\s+Transfer\s+(Bitrate|Bandwidth)")
 
     def _parse_headers(self, line):
-        self.logger.info(f"LINE: --- {line}")
         if self._regex_helper.search_compiled(Iperf3._re_headers, line):
             if self.parallel_client:
                 client, server = list(self._connection_dict.values())[0]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open(join(getcwd(), 'requirements', 'base.txt'), encoding='utf-8') as f:
 
 setup(
     name='moler',
-    version='3.6.0',
+    version='3.7.0',
     description='Moler is a library for working with terminals, mainly for automated tests',  # Required
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
In iperf3 versions 3.2 and above the parameter 'Bitrate' is used, however in versions 3.1.7 and below 'Bandwidth' parameter like in iperf2 is still used. Regex for _parse_headers inside Iperf3 class has been changed to allow both Bitrate and Bandwidth paramteres.