### PR TITLE
Change ctrl+z stopping condition in GenericUnixCmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## moler 3.9.0
+ * Change way of validating if Ctrl+Z has worked and stopped the command
+
 ## moler 3.8.0
  * More info when SshShell is disconnected
  * Fix prompt detection for ProxyPc2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![image](https://img.shields.io/badge/pypi-v3.8.0-blue.svg)](https://pypi.org/project/moler/)
+[![image](https://img.shields.io/badge/pypi-v3.9.0-blue.svg)](https://pypi.org/project/moler/)
 [![image](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue.svg)](https://pypi.org/project/moler/)
 [![Build Status](https://github.com/nokia/moler/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/nokia/moler/actions)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](./LICENSE)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2019-2024, Nokia'
 author = 'Nokia'
 
 # The short X.Y version
-version = '3.8.0'
+version = '3.9.0'
 # The full version, including alpha/beta/rc tags
 release = 'stable'
 

--- a/moler/cmd/unix/genericunix.py
+++ b/moler/cmd/unix/genericunix.py
@@ -134,9 +134,6 @@ class GenericUnixCommand(CommandTextualGeneric):
     # [2]+  Stopped
     _re_ctrl_z_stopped = re.compile(r"\[(?P<JOB_ID>\d+)\]\+\s+Stopped")
 
-    # [2]+  Done
-    _re_kill_done = re.compile(r"\[?\d+\]\+\s+Done")
-
     # -bash: wait: %2: no such job
     _re_kill_no_job = re.compile(r"\:\s+\%\d+\s?\:\s+no such job")
 

--- a/moler/cmd/unix/genericunix.py
+++ b/moler/cmd/unix/genericunix.py
@@ -155,8 +155,6 @@ class GenericUnixCommand(CommandTextualGeneric):
             self._kill_ctrl_z_sent = True
             raise ParsingDone()
 
-        if self._kill_ctrl_z_sent and (
-            self._regex_helper.search_compiled(GenericUnixCommand._re_kill_done, line) or self._regex_helper.search_compiled(GenericUnixCommand._re_kill_no_job, line)
-        ):
+        if self._kill_ctrl_z_sent and self._regex_helper.search_compiled(GenericUnixCommand._re_kill_no_job, line):
             self._kill_ctrl_z_job_done = True
             raise ParsingDone()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open(join(getcwd(), 'requirements', 'base.txt'), encoding='utf-8') as f:
 
 setup(
     name='moler',
-    version='3.8.0',
+    version='3.8.1',
     description='Moler is a library for working with terminals, mainly for automated tests',  # Required
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/test/cmd/unix/test_cmd_run_script.py
+++ b/test/cmd/unix/test_cmd_run_script.py
@@ -66,7 +66,8 @@ def test_run_script_ctrl_z(buffer_connection):
     output4 = "moler_bash# kill %4; wait %4\n"
     output5 = f"\n{output3}\n"
     output6 = f"[4]+  Done                 {output1}\n"
-    output7 = "moler_bash#"
+    output7 = "moler_bash# wait: %4: no such job\n"
+    output8 = "moler_bash#"
     cmd = RunScript(connection=buffer_connection.moler_connection, script_command=output1)
     cmd.set_timeout_action(action='z')
     assert cmd._cmd_output_started is False
@@ -92,6 +93,8 @@ def test_run_script_ctrl_z(buffer_connection):
     buffer_connection.moler_connection.data_received(output6.encode("utf-8"), datetime.datetime.now())
     time.sleep(0.1)
     buffer_connection.moler_connection.data_received(output7.encode("utf-8"), datetime.datetime.now())
+    time.sleep(0.1)
+    buffer_connection.moler_connection.data_received(output8.encode("utf-8"), datetime.datetime.now())
     assert cmd._kill_ctrl_z_job_done is True
     with pytest.raises(CommandTimeout):
         cmd.await_done()


### PR DESCRIPTION
With the previous version there used to be an issue with stopping the command, it did not raise the ParsingDone correctly. This way seemed to work for more cases